### PR TITLE
Copy over .env and package.json files on build

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -51,6 +51,6 @@
     "typeorm": "ts-node -r tsconfig-paths/register ../node_modules/typeorm/cli.js",
     "test": "jest --runInBand",
     "test:circleci": "cross-env NODE_ENV=circleci jest --runInBand",
-    "production": "tsc && cross-env NODE_ENV=production node ./build/src/index.js"
+    "production": "tsc && cp .env ./build/ && cp package.json ./build/ && cd ./build && yarn install && cross-env NODE_ENV=production node ./src/index.js"
   }
 }


### PR DESCRIPTION
This change prevents node from using the current source folder as its execution directory.
When the current source is used, the .ts files take precedence in the module loader and throws errors in a .js only environment.