### PR TITLE
Use ReversedChip component

### DIFF
--- a/frontend/src/AuthenticatedApp/paperGrading/MarkQuestionPage/index.tsx
+++ b/frontend/src/AuthenticatedApp/paperGrading/MarkQuestionPage/index.tsx
@@ -28,6 +28,7 @@ import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
 import { lightBlue } from "@material-ui/core/colors";
 
 import LoadingSpinner from "../../../components/LoadingSpinner";
+import ReversedChip from "../../../components/ReversedChip";
 import Annotator from "./Annotator";
 import MarkQuestionModal from "./MarkQuestionModal";
 
@@ -190,23 +191,26 @@ const MarkQuestionPage: React.FC<Props> = ({ match }) => {
         .map(page => {
           console.log(page.imageUrl);
           return (
-          <div className={classes.grow}>
-            {page.pageNo === pageNo && (
-              <>
-              <Annotator
-                key={page.id}
-                pageId={page.id}
-                backgroundImageSource={page.imageUrl}
-                foregroundAnnotation={
-                  page.annotations.length > 0 ? page.annotations[0].layer : []
-                }
-              />
-              image
-              <img src={page.imageUrl}/>
-              </>
-            )}
-          </div>
-        )})}
+            <div className={classes.grow}>
+              {page.pageNo === pageNo && (
+                <>
+                  <Annotator
+                    key={page.id}
+                    pageId={page.id}
+                    backgroundImageSource={page.imageUrl}
+                    foregroundAnnotation={
+                      page.annotations.length > 0
+                        ? page.annotations[0].layer
+                        : []
+                    }
+                  />
+                  image
+                  <img src={page.imageUrl} />
+                </>
+              )}
+            </div>
+          );
+        })}
       <AppBar position="fixed" color="inherit" className={classes.questionBar}>
         <Toolbar>
           <Typography variant="button" className={classes.questionBarItem}>
@@ -217,7 +221,7 @@ const MarkQuestionPage: React.FC<Props> = ({ match }) => {
               key={question.id}
               question={question}
               render={(toggleVisibility, score, name) => (
-                <Chip
+                <ReversedChip
                   onClick={toggleVisibility}
                   label={"Q" + name}
                   avatar={<Avatar>{score || "-"}</Avatar>}

--- a/frontend/src/AuthenticatedApp/paperScripts/ScriptView/index.tsx
+++ b/frontend/src/AuthenticatedApp/paperScripts/ScriptView/index.tsx
@@ -24,6 +24,7 @@ import { lightBlue } from "@material-ui/core/colors";
 
 import { CanvasWithToolbar } from "../../../components/Canvas";
 import LoadingSpinner from "../../../components/LoadingSpinner";
+import ReversedChip from "../../../components/ReversedChip";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -189,7 +190,7 @@ const ScriptView: React.FC<Props> = ({ match: { params } }) => {
               {matriculationNumber} Page {pageNo} of {pages.length}
             </Typography>
             {getCurrentPageQuestions().map(question => (
-              <Chip
+              <ReversedChip
                 key={question.id}
                 avatar={<Avatar>{question.score || "-"}</Avatar>}
                 label={question.name}

--- a/frontend/src/components/Canvas/Canvas.tsx
+++ b/frontend/src/components/Canvas/Canvas.tsx
@@ -254,14 +254,7 @@ const Canvas: React.FC<CanvasProps> = ({
           y: stage.getPointerPosition().y / oldScale - stage.y() / oldScale
         };
 
-        const unboundedNewScale = oldScale - event.evt.deltaY * 0.01;
-        let newScale = unboundedNewScale;
-        if (unboundedNewScale < 0.1) {
-          newScale = 0.1;
-        } else if (unboundedNewScale > 10.0) {
-          newScale = 10.0;
-        }
-
+        const newScale = oldScale - event.evt.deltaY * 0.01;
         const newPosition = {
           x:
             -(mousePointTo.x - stage.getPointerPosition().x / newScale) *
@@ -368,7 +361,6 @@ const Canvas: React.FC<CanvasProps> = ({
           });
         }
         if (!canvasState.lastPointerPosition) {
-          // canvasState.lastPointerPosition = { x: currX, y: currY };
           dispatch({
             type: CanvasActionType.PanZoom,
             payload: {

--- a/frontend/src/components/Canvas/CanvasWithToolbar.tsx
+++ b/frontend/src/components/Canvas/CanvasWithToolbar.tsx
@@ -91,6 +91,8 @@ const CanvasWithToolbar: React.FC<Props> = ({
   const [scale, setScale] = useState<number>(defaultScale);
   const handleViewChange = (position: Point, scale: number) => {
     setPosition(position);
+    let clampedScale = scale > 10.0 ? 10.0 : scale;
+    clampedScale = scale < 0.1 ? 0.1 : clampedScale;
     setScale(scale);
   };
   const handleZoomOutClick = event =>

--- a/frontend/src/components/ReversedChip.tsx
+++ b/frontend/src/components/ReversedChip.tsx
@@ -1,0 +1,15 @@
+import Chip from "@material-ui/core/Chip";
+import { withStyles } from "@material-ui/core/styles";
+
+const ReversedChip = withStyles({
+  root: {
+    direction: "rtl",
+    "& $avatar": {
+      marginLeft: "-6px",
+      marginRight: "5px"
+    }
+  },
+  avatar: {}
+})(Chip);
+
+export default ReversedChip;


### PR DESCRIPTION
<img width="64" alt="Screenshot 2019-11-16 at 2 12 14 PM" src="https://user-images.githubusercontent.com/29230362/68988989-39168c00-087b-11ea-89dc-9afc975fbd4f.png">

`import ReversedChip from "components/ReversedChip";`

Drop-in replacement for Chip that puts the label on the left and the avatar on the right.
Use it like you use the normal Chip - all the props are the same, only the styling changed.

Also minor update to clamp scale in CanvasWithToolbar instead of hardcoding in Canvas.