### PR TITLE
Fallback fix for disappearing annotations (CSS trick method)

### DIFF
--- a/frontend/src/AuthenticatedApp/paperGrading/MarkQuestionSubpage/index.tsx
+++ b/frontend/src/AuthenticatedApp/paperGrading/MarkQuestionSubpage/index.tsx
@@ -230,7 +230,7 @@ const MarkQuestionPage: React.FC = () => {
         );
       });
 
-    const getCurrentPageQuestions = () => {
+    const getCurrentPageQuestions = (pageNo: number) => {
       const currentPage = pages.find(page => page.pageNo === pageNo)!;
       const currentPageQuestions = questions.filter(question =>
         currentPage.questionIds.includes(question.id)
@@ -241,20 +241,22 @@ const MarkQuestionPage: React.FC = () => {
     return (
       <div className={classes.container}>
         <Header subtitle={`Marking Q${rootQuestionTemplate.name}`} />
-        {pages
-          .filter(page => page.pageNo === pageNo)
-          .map((page, index) => {
-            return (
-              <div className={classes.grow} key={index}>
-                <Annotator
-                  key={page.id}
-                  page={page}
-                  questions={getCurrentPageQuestions()}
-                  rootQuestionTemplate={rootQuestionTemplate}
-                />
-              </div>
-            );
-          })}
+        {pages.map((page, index) => {
+          return (
+            <div
+              className={classes.grow}
+              key={index}
+              style={{ display: page.pageNo === pageNo ? "flex" : "none" }}
+            >
+              <Annotator
+                key={page.id}
+                page={page}
+                questions={getCurrentPageQuestions(page.pageNo)}
+                rootQuestionTemplate={rootQuestionTemplate}
+              />
+            </div>
+          );
+        })}
         {pageNo !== pageNos[0] && (
           <IconButton
             onClick={decrementPageNo}

--- a/frontend/src/AuthenticatedApp/paperScripts/ScriptMarkSubpage/index.tsx
+++ b/frontend/src/AuthenticatedApp/paperScripts/ScriptMarkSubpage/index.tsx
@@ -201,7 +201,7 @@ const ScriptMarkPage: React.FC = () => {
         );
       });
 
-    const getCurrentPageQuestions = () => {
+    const getCurrentPageQuestions = (pageNo: number) => {
       const currentPage = pages.find(page => page.pageNo === pageNo)!;
       const currentPageQuestions = questions.filter(question =>
         currentPage.questionIds.includes(question.id)
@@ -216,20 +216,22 @@ const ScriptMarkPage: React.FC = () => {
             rootQuestionTemplate.name
           }`}
         />
-        {pages
-          .filter(page => page.pageNo === pageNo)
-          .map((page, index) => {
-            return (
-              <div className={classes.grow} key={index}>
-                <Annotator
-                  key={page.id}
-                  page={page}
-                  questions={getCurrentPageQuestions()}
-                  rootQuestionTemplate={rootQuestionTemplate}
-                />
-              </div>
-            );
-          })}
+        {pages.map((page, index) => {
+          return (
+            <div
+              className={classes.grow}
+              key={index}
+              style={{ display: page.pageNo === pageNo ? "flex" : "none" }}
+            >
+              <Annotator
+                key={page.id}
+                page={page}
+                questions={getCurrentPageQuestions(page.pageNo)}
+                rootQuestionTemplate={rootQuestionTemplate}
+              />
+            </div>
+          );
+        })}
         {pageNo !== pageNos[0] && (
           <IconButton
             onClick={decrementPageNo}


### PR DESCRIPTION
Fallback fix for disappearing annotations by mounting and rendering all pages but making only one visible with CSS. This means all pages are in memory, hence the state for each page is not reset upon changing pages. 